### PR TITLE
Add Linux build, run checks on both OSes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,10 @@ permissions:
 
 jobs:
   check:
-    runs-on: windows-latest
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,7 +57,7 @@ jobs:
           report_type: test_results
           files: junit.xml
 
-  build:
+  build-windows:
     needs: check
     runs-on: windows-latest
     steps:
@@ -78,7 +81,7 @@ jobs:
         with:
           path: |
             ~\AppData\Local\Nuitka
-          key: nuitka-py3.12-${{ hashFiles('uv.lock') }}
+          key: nuitka-windows-py3.12-${{ hashFiles('uv.lock') }}
 
       - name: Build
         run: |
@@ -87,31 +90,78 @@ jobs:
           Get-Item -Path build\snapjaw.dist\* | Move-Item -Destination build\snapjaw\snapjaw
 
       - name: Package
-        run: Compress-Archive -Path build\snapjaw\* -DestinationPath snapjaw.zip
+        run: Compress-Archive -Path build\snapjaw\* -DestinationPath snapjaw-windows-x86_64.zip
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: snapjaw
-          path: snapjaw.zip
+          name: snapjaw-windows-x86_64
+          path: snapjaw-windows-x86_64.zip
+
+  build-linux:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          architecture: x64
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Cache Nuitka
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/Nuitka
+          key: nuitka-linux-py3.12-${{ hashFiles('uv.lock') }}
+
+      - name: Build
+        run: uv run nuitka --onefile --prefer-source-code --assume-yes-for-downloads --show-scons --output-dir=build --include-module=_cffi_backend src/snapjaw.py
+
+      - name: Package
+        run: |
+          mv build/snapjaw.bin snapjaw
+          tar czf snapjaw-linux-x86_64.tar.gz snapjaw
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapjaw-linux-x86_64
+          path: snapjaw-linux-x86_64.tar.gz
 
   release:
-    needs: build
+    needs: [build-windows, build-linux]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - name: Download artifact
+      - name: Download artifacts
         uses: actions/download-artifact@v4
-        with:
-          name: snapjaw
 
       - name: Get date
         id: date
         run: echo "date=$(date +%Y.%m.%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Rename artifacts
+        env:
+          VERSION: ${{ steps.date.outputs.date }}.${{ github.run_number }}
+        run: |
+          mv snapjaw-windows-x86_64/snapjaw-windows-x86_64.zip snapjaw-${VERSION}-windows-x86_64.zip
+          mv snapjaw-linux-x86_64/snapjaw-linux-x86_64.tar.gz snapjaw-${VERSION}-linux-x86_64.tar.gz
 
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.date.outputs.date }}.${{ github.run_number }}
           name: ${{ steps.date.outputs.date }}.${{ github.run_number }}
-          files: snapjaw.zip
+          files: |
+            snapjaw-${{ steps.date.outputs.date }}.${{ github.run_number }}-windows-x86_64.zip
+            snapjaw-${{ steps.date.outputs.date }}.${{ github.run_number }}-linux-x86_64.tar.gz

--- a/README.md
+++ b/README.md
@@ -13,9 +13,22 @@
 - Simple command line interface
 
 ## How to install
-- [Download snapjaw](https://github.com/refaim/snapjaw/releases/latest)
+
+### Windows
+- [Download snapjaw](https://github.com/refaim/snapjaw/releases/latest) (the `.zip` file)
 - Extract the archive into the WoW folder. This will create a structure similar to `C:\Games\WoW\snapjaw\snapjaw.exe`. Alternatively, if you choose a different destination, you'll need to specify the path to the addons directory using the `--addons-dir` argument.
 - See usage examples or run `snapjaw.exe --help`
+
+### Linux
+- [Download snapjaw](https://github.com/refaim/snapjaw/releases/latest) (the `.tar.gz` file)
+- Extract and install:
+  ```
+  tar xzf snapjaw-*-linux-x86_64.tar.gz
+  chmod +x snapjaw
+  mv snapjaw ~/.local/bin/
+  ```
+- Run from your WoW directory: `cd /path/to/wow && snapjaw --help`
+- Or use `--addons-dir` to specify the path to `Interface/Addons` from anywhere
 
 #### Note
 If you are new to snapjaw, you will need to reinstall each of your addons manually using the `snapjaw install` command. This process is essential as it creates an index file to effectively track the status of your addons folder.


### PR DESCRIPTION
- Add build-linux job using Nuitka --onefile for a single binary
- Rename build to build-windows, update artifact names with OS and CPU
- Add version to release filenames (snapjaw-VERSION-os-arch)
- Run check job on both Windows and Ubuntu via matrix